### PR TITLE
ScatterWidget return labels instead of colors

### DIFF
--- a/drawdata/__init__.py
+++ b/drawdata/__init__.py
@@ -47,16 +47,16 @@ class ScatterWidget(anywidget.AnyWidget):
     def data_as_X_y(self):
         import numpy as np
 
-        colors = [_['color'] for _ in self.data]
+        labels = [_['label'] for _ in self.data]  # Updated to use 'label' instead of 'color'
         
         # Assume that we're dealing with regression in this case
-        if np.unique(colors).shape[0] == 1:
+        if np.unique(labels).shape[0] == 1:
             X = np.array([[_['x']] for _ in self.data])
             y = np.array([_['y'] for _ in self.data])
             return X, y
         
         X = np.array([[_['x'], _['y']] for _ in self.data])
-        return X, colors
+        return X, labels
 
 
 class BarWidget(anywidget.AnyWidget):


### PR DESCRIPTION
Noticed that the `.data_as_pandas` returns a df containing both **colors** and **labels**. Whereas the `.data_as_X_y` returns **colors**, which isn't very useful when interpreting and working with the data.

**Update**: Modified the ScatterWidget class so that `.data_as_X_y` now returns **labels** instead of **colors**.
**Question**: Was there a specific reason for returning color instead of label? Happy to discuss if there's a particular use case for it!