### PR TITLE
Fix BarWidget CSS leakage by scoping selectors

### DIFF
--- a/drawdata/static/bar_widget.css
+++ b/drawdata/static/bar_widget.css
@@ -1,54 +1,54 @@
-.container {
+.dd-bar-container {
     max-width: 800px;
     margin: 20px auto;
     font-family: Arial, sans-serif;
 }
-.controls {
+.dd-bar-controls {
     margin-bottom: 20px;
 }
-.chart-container {
+.dd-bar-container .chart-container {
     border: 1px solid #ccc;
     margin-bottom: 20px;
 }
-button.control {
+button.dd-bar-control {
     padding: 8px 16px;
     margin: 0 5px;
     cursor: pointer;
     background-color: #eee;
     border: 1px solid #ccc;
 }
-button.reset {
+button.dd-bar-reset {
     padding: 8px 16px;
     margin: 0 5px;
     cursor: pointer;
     background-color: #eee;
     border: 1px solid #ccc;
 }
-.active {
+.dd-bar-active {
     border: 4px solid #333;
     background-color: #ddd;
     font-weight: bold;
 }
-input[type="number"] {
+.dd-bar-container input[type="number"] {
     width: 80px;
     padding: 5px;
     margin: 0 5px;
 }
-label {
+.dd-bar-container label {
     margin-right: 10px;
 }
-.bar {
+.dd-bar-container .bar {
     opacity: 0.6;
     transition: opacity 0.2s;
 }
-.bar:hover {
+.dd-bar-container .bar:hover {
     opacity: 0.8;
 }
-.grid line {
+.dd-bar-container .grid line {
     stroke: #ddd;
     stroke-opacity: 0.7;
 }
-.domain {
+.dd-bar-container .domain {
     stroke: #000;
     stroke-width: 1px;
 }

--- a/drawdata/static/bar_widget.js
+++ b/drawdata/static/bar_widget.js
@@ -9557,12 +9557,13 @@ function render({ model, el }) {
   updateDataOut();
   getBins();
   let container = document.createElement("div");
+  container.setAttribute("class", "dd-bar-container");
   let controls = document.createElement("div");
-  controls.setAttribute("class", "controls");
+  controls.setAttribute("class", "dd-bar-controls");
   if (Object.keys(collections).length > 1) {
     Object.keys(collections).forEach((key) => {
       let btn = document.createElement("button");
-      btn.setAttribute("class", "control");
+      btn.setAttribute("class", "dd-bar-control");
       btn.style.position = "relative";
       btn.style.paddingLeft = "30px";
       let circle = document.createElement("span");
@@ -9587,7 +9588,7 @@ function render({ model, el }) {
     });
   }
   let clear_btn = document.createElement("button");
-  clear_btn.setAttribute("class", "reset");
+  clear_btn.setAttribute("class", "dd-bar-reset");
   clear_btn.innerHTML = "Clear";
   if (Object.keys(collections).length > 1) {
     controls.appendChild(clear_btn);
@@ -9683,10 +9684,10 @@ function render({ model, el }) {
   chartArea.on("mouseleave", () => {
     isDrawing = false;
   });
-  document.querySelectorAll("button.control").forEach((button) => {
+  container.querySelectorAll("button.dd-bar-control").forEach((button) => {
     button.addEventListener("click", () => {
-      document.querySelectorAll("button.control").forEach((b) => b.classList.remove("active"));
-      button.classList.add("active");
+      container.querySelectorAll("button.dd-bar-control").forEach((b) => b.classList.remove("dd-bar-active"));
+      button.classList.add("dd-bar-active");
       activeCollection = button.querySelector("span").textContent;
     });
   });
@@ -9697,7 +9698,7 @@ function render({ model, el }) {
     updateChart();
   });
   if (Object.keys(collections).length > 1) {
-    document.querySelector("button.control").click();
+    container.querySelector("button.dd-bar-control").click();
   }
   updateChart();
 }

--- a/js/bar_widget.js
+++ b/js/bar_widget.js
@@ -30,15 +30,16 @@ function render({ model, el }) {
     // Create SVG
     getBins();
     let container = document.createElement("div");
+    container.setAttribute("class", "dd-bar-container");
     
     let controls = document.createElement("div");
-    controls.setAttribute("class", "controls");
+    controls.setAttribute("class", "dd-bar-controls");
 
     // Only add collection buttons if there are multiple collections
     if (Object.keys(collections).length > 1) {
         Object.keys(collections).forEach(key => {
             let btn = document.createElement("button");
-            btn.setAttribute("class", "control")
+            btn.setAttribute("class", "dd-bar-control")
             btn.style.position = "relative";
             btn.style.paddingLeft = "30px";
             let circle = document.createElement("span");
@@ -64,7 +65,7 @@ function render({ model, el }) {
     }
     // Add a button to clear the chart
     let clear_btn = document.createElement("button");
-    clear_btn.setAttribute("class", "reset");
+    clear_btn.setAttribute("class", "dd-bar-reset");
     clear_btn.innerHTML = "Clear";
     if (Object.keys(collections).length > 1) {
         controls.appendChild(clear_btn);
@@ -249,10 +250,10 @@ function render({ model, el }) {
     });
 
     // Handle collection selection
-    document.querySelectorAll('button.control').forEach(button => {
+    container.querySelectorAll('button.dd-bar-control').forEach(button => {
         button.addEventListener('click', () => {
-            document.querySelectorAll('button.control').forEach(b => b.classList.remove('active'));
-            button.classList.add('active');
+            container.querySelectorAll('button.dd-bar-control').forEach(b => b.classList.remove('dd-bar-active'));
+            button.classList.add('dd-bar-active');
             activeCollection = button.querySelector('span').textContent;
         });
     });
@@ -266,7 +267,7 @@ function render({ model, el }) {
     });
 
     if (Object.keys(collections).length > 1) {
-        document.querySelector('button.control').click();
+        container.querySelector('button.dd-bar-control').click();
     }
 
     // Initialize chart

--- a/tests/test_bar_widget_scoping.py
+++ b/tests/test_bar_widget_scoping.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+import re
+
+
+def test_bar_widget_css_is_scoped_to_widget_container():
+    css = Path("drawdata/static/bar_widget.css").read_text(encoding="utf-8")
+
+    # Ensure we expose a widget-specific root class for all styling.
+    assert ".dd-bar-container {" in css
+
+    leaked_global_selectors = [
+        r"^\.container\s*\{",
+        r"^\.controls\s*\{",
+        r"^\.active\s*\{",
+        r"^label\s*\{",
+        r"^input\[type=\"number\"\]\s*\{",
+    ]
+
+    for pattern in leaked_global_selectors:
+        assert re.search(pattern, css, flags=re.MULTILINE) is None
+
+
+def test_bar_widget_button_selection_is_container_scoped():
+    js = Path("drawdata/static/bar_widget.js").read_text(encoding="utf-8")
+
+    assert 'container.querySelectorAll("button.dd-bar-control")' in js
+    assert 'container.querySelector("button.dd-bar-control")' in js
+    assert 'document.querySelectorAll("button.control")' not in js
+    assert 'document.querySelector("button.control")' not in js


### PR DESCRIPTION
## Description:

Issue #26 reported that BarWidget CSS leaked into other notebook outputs because generic selectors such as .container and label were globally applied.

This PR updates BarWidget styling, and control selection to use widget scoped classes in both source, and bundled JS paths, preserving styling isolation across notebook outputs.

It also adds regression tests that cover selector scoping and container scoped control selection.

Closes #26.

## Checklist:

- [x] I have reviewed all changes in this PR myself.
- [x] I have added relevant regression test cases for this fix.
- [x] I have run linting and formatting checks in WSL using `ruff check tests/test_bar_widget_scoping.py`.
- [x] I have run focused tests in WSL using `pytest -q tests/test_bar_widget_scoping.py`.
- [x] I have run full tests in WSL using `pytest -q`.
- [x] I manually validated the visual behavior, and confirmed no CSS leakage to external .container elements.

#### The validation screenshots of the tests run (include visual test), locally on WSL:

<img width="1431" height="217" alt="Screenshot 2026-04-22 200857" src="https://github.com/user-attachments/assets/03b39aeb-0111-4f04-b100-0ec515e61a7f" />


<img width="844" height="581" alt="Screenshot 2026-04-22 200846" src="https://github.com/user-attachments/assets/2114599c-2c9e-44a2-844b-7c7bbc0c2f98" />


