### PR TITLE
Extend ScatterWidget classes and BarWidget palette up to 20

### DIFF
--- a/bar-demo.py
+++ b/bar-demo.py
@@ -13,7 +13,12 @@ def __():
 
 @app.cell
 def __(BarWidget, mo):
-    widget = mo.ui.anywidget(BarWidget(height=400, width=700, n_bins=24))
+    widget = mo.ui.anywidget(BarWidget(
+        height=400,
+        width=700,
+        n_bins=24,
+        collection_names=["collection1", "collection2", "collection3", "collection4", "collection5"],
+    ))
     widget
     return (widget,)
 

--- a/drawdata/__init__.py
+++ b/drawdata/__init__.py
@@ -19,8 +19,8 @@ class ScatterWidget(anywidget.AnyWidget):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        if not 1 <= self.n_classes <= 4:
-            raise ValueError('n_classes must be between 1 and 4')
+        if not 1 <= self.n_classes <= 20:
+            raise ValueError('n_classes must be between 1 and 20')
 
     @property
     def data_as_pandas(self):

--- a/drawdata/static/bar_widget.js
+++ b/drawdata/static/bar_widget.js
@@ -9538,13 +9538,18 @@ function render({ model, el }) {
   const width = model.get("width") - margin.left - margin.right;
   const height = model.get("height") - margin.top - margin.bottom;
   const userNames = model.get("collection_names");
-  const colors = ["#36A2EB", "#FFCE56", "#4BC0C0", "#FF6384"];
+  const colors = [
+    "#36A2EB", "#FFCE56", "#4BC0C0", "#FF6384", "#9966FF",
+    "#FF9F40", "#8AC926", "#1982C4", "#6A4C93", "#C9CBCF",
+    "#E63946", "#06A77D", "#264653", "#E76F51", "#B5179E",
+    "#80B918", "#4CC9F0", "#3A0CA3", "#F4A261", "#A0522D"
+  ];
   const collections = {};
   const numCollections = Math.max(1, userNames.length);
   for (let i = 0; i < numCollections; i++) {
     const name = userNames[i] || `collection${i + 1}`;
     collections[name] = {
-      color: colors[i],
+      color: colors[i % colors.length],
       data: new Array(model.get("n_bins")).fill(model.get("y_min"))
     };
   }

--- a/drawdata/static/scatter_widget.js
+++ b/drawdata/static/scatter_widget.js
@@ -9534,8 +9534,16 @@ var require_d3_v7 = __commonJS({
 // js/scatter_widget.js
 var d3 = __toESM(require_d3_v7());
 function render({ model, el }) {
-  const allColors = ["#1f77b4", "#ff7f0e", "#2ca02c", "#d62728"];
-  const allClassNames = ["a", "b", "c", "d"];
+  const allColors = [
+    "#1f77b4", "#ff7f0e", "#2ca02c", "#d62728", "#9467bd",
+    "#8c564b", "#e377c2", "#7f7f7f", "#bcbd22", "#17becf",
+    "#aec7e8", "#ffbb78", "#98df8a", "#ff9896", "#c5b0d5",
+    "#c49c94", "#f7b6d2", "#c7c7c7", "#dbdb8d", "#9edae5"
+  ];
+  const allClassNames = [
+    "a", "b", "c", "d", "e", "f", "g", "h", "i", "j",
+    "k", "l", "m", "n", "o", "p", "q", "r", "s", "t"
+  ];
   const n_classes = model.get("n_classes") || 4;
   const colors = allColors.slice(0, n_classes);
   const classNames = allClassNames.slice(0, n_classes);

--- a/js/bar_widget.js
+++ b/js/bar_widget.js
@@ -8,15 +8,20 @@ function render({ model, el }) {
 
     // Initialize collections with names from model
     const userNames = model.get("collection_names");
-    const colors = ['#36A2EB', '#FFCE56', '#4BC0C0', '#FF6384'];
-    
+    const colors = [
+        '#36A2EB', '#FFCE56', '#4BC0C0', '#FF6384', '#9966FF',
+        '#FF9F40', '#8AC926', '#1982C4', '#6A4C93', '#C9CBCF',
+        '#E63946', '#06A77D', '#264653', '#E76F51', '#B5179E',
+        '#80B918', '#4CC9F0', '#3A0CA3', '#F4A261', '#A0522D'
+    ];
+
     const collections = {};
     // Only create collections for the provided names (or at least one if none provided)
     const numCollections = Math.max(1, userNames.length);
     for (let i = 0; i < numCollections; i++) {
         const name = userNames[i] || `collection${i + 1}`;
         collections[name] = {
-            color: colors[i],
+            color: colors[i % colors.length],
             data: new Array(model.get("n_bins")).fill(model.get("y_min"))
         };
     };

--- a/js/scatter_widget.js
+++ b/js/scatter_widget.js
@@ -1,9 +1,17 @@
 import * as d3 from "./d3.v7.js";
 
 function render({ model, el }) {
-  // Full set of available colors and class names
-  const allColors = ["#1f77b4", "#ff7f0e", "#2ca02c", "#d62728"];
-  const allClassNames = ["a", "b", "c", "d"];
+  // Full set of available colors and class names (matplotlib tab20 palette)
+  const allColors = [
+    "#1f77b4", "#ff7f0e", "#2ca02c", "#d62728", "#9467bd",
+    "#8c564b", "#e377c2", "#7f7f7f", "#bcbd22", "#17becf",
+    "#aec7e8", "#ffbb78", "#98df8a", "#ff9896", "#c5b0d5",
+    "#c49c94", "#f7b6d2", "#c7c7c7", "#dbdb8d", "#9edae5"
+  ];
+  const allClassNames = [
+    "a", "b", "c", "d", "e", "f", "g", "h", "i", "j",
+    "k", "l", "m", "n", "o", "p", "q", "r", "s", "t"
+  ];
 
   // Get number of classes (default to 4 for backward compatibility)
   const n_classes = model.get("n_classes") || 4;

--- a/scatter-demo.py
+++ b/scatter-demo.py
@@ -33,7 +33,7 @@ def _(mo):
 
 @app.cell(hide_code=True)
 def _(ScatterWidget, mo):
-    widget = mo.ui.anywidget(ScatterWidget(height=400))
+    widget = mo.ui.anywidget(ScatterWidget(height=400, n_classes=10))
     widget
     return (widget,)
 


### PR DESCRIPTION
ScatterWidget previously hard-capped n_classes at 4. Raise the limit to 20 and extend allColors and allClassNames in the JS to match (matplotlib tab20 palette; class names a..t). The first 4 entries are unchanged so existing behaviour is preserved.

BarWidget similarly gains a 20-color palette and falls back to modulo indexing past 20 to avoid undefined colors.

Demo files updated to exercise the new capacity.